### PR TITLE
encode space to conform new gfm specs

### DIFF
--- a/Part 1 - Getting Started/1. Why Rx.md
+++ b/Part 1 - Getting Started/1. Why Rx.md
@@ -45,5 +45,5 @@ Those patterns are already well adopted and you may find that introducing Rx on 
 
 | Previous | Next |
 | --- | --- |
-|   | [Key types](/Part 1 - Getting Started/2. Key types.md) |
+|   | [Key types](/Part%201%20-%20Getting%20Started/2.%20Key%20types.md) |
 

--- a/Part 1 - Getting Started/2. Key types.md
+++ b/Part 1 - Getting Started/2. Key types.md
@@ -243,4 +243,4 @@ Safety nets like these are not guaranteed in the entirety of the implementation 
 
 | Previous | Next |
 | --- | --- |
-| [Why Rx](/Part 1 - Getting Started/1. Why Rx.md) | [Lifetime management](/Part 1 - Getting Started/3. Lifetime management.md) |
+| [Why Rx](/Part%201%20-%20Getting%20Started/1.%20Why%20Rx.md) | [Lifetime management](/Part%201%20-%20Getting%20Started/3.%20Lifetime%20management.md) |

--- a/Part 1 - Getting Started/3. Lifetime management.md
+++ b/Part 1 - Getting Started/3. Lifetime management.md
@@ -151,4 +151,4 @@ We will see more of them later in this book. It is interesting to note that `Sub
 
 | Previous | Next |
 | --- | --- |
-| [Key types](/Part 1 - Getting Started/2. Key types.md) | [Chapter 2](/Part 2 - Sequence Basics/1. Creating a sequence.md) |
+| [Key types](/Part%201%20-%20Getting%20Started/2.%20Key%20types.md) | [Chapter 2](/Part%202%20-%20Sequence%20Basics/1.%20Creating%20a%20sequence.md) |

--- a/Part 2 - Sequence Basics/1. Creating a sequence.md
+++ b/Part 2 - Sequence Basics/1. Creating a sequence.md
@@ -302,4 +302,4 @@ Completed
 
 | Previous | Next |
 | --- | --- |
-| [Lifetime management](/Part 1 - Getting Started/3. Lifetime management.md) | [Reducing a sequence](/Part 2 - Sequence Basics/2. Reducing a sequence.md) |
+| [Lifetime management](/Part%201%20-%20Getting%20Started/3.%20Lifetime%20management.md) | [Reducing a sequence](/Part%202%20-%20Sequence%20Basics/2.%20Reducing%20a%20sequence.md) |

--- a/Part 2 - Sequence Basics/2. Reducing a sequence.md
+++ b/Part 2 - Sequence Basics/2. Reducing a sequence.md
@@ -441,4 +441,4 @@ Subscription subscription = values
 
 | Previous | Next |
 | --- | --- |
-| [Creating a sequence](/Part 2 - Sequence Basics/1. Creating a sequence.md) | [Inspection](/Part 2 - Sequence Basics/3. Inspection.md) |
+| [Creating a sequence](/Part%202%20-%20Sequence%20Basics/1.%20Creating%20a%20sequence.md) | [Inspection](/Part%202%20-%20Sequence%20Basics/3.%20Inspection.md) |

--- a/Part 2 - Sequence Basics/3. Inspection.md
+++ b/Part 2 - Sequence Basics/3. Inspection.md
@@ -338,4 +338,5 @@ Error: java.lang.Exception
 
 | Previous | Next |
 | --- | --- |
-| [Reducing a sequence](/Part 2 - Sequence Basics/2. Reducing a sequence.md) | [Aggregation](/Part 2 - Sequence Basics/4. Aggregation.md) |
+| [Reducing a sequence](/Part%202%20-%20Sequence%20Basics/2.%20Reducing%20a%20sequence.md) | [Aggregation](/Part%202%20-%20Sequence%20Basics/4.%20Aggregation.md) |
+

--- a/Part 2 - Sequence Basics/4. Aggregation.md
+++ b/Part 2 - Sequence Basics/4. Aggregation.md
@@ -567,4 +567,4 @@ Nesting observables to consume them doesn't make much sense. Towards the end of 
 
 | Previous | Next |
 | --- | --- |
-| [Inspection](/Part 2 - Sequence Basics/3. Inspection.md) | [Transformation of sequences](/Part 2 - Sequence Basics/5. Transformation of sequences.md) |
+| [Inspection](/Part%202%20-%20Sequence%20Basics/3.%20Inspection.md) | [Transformation of sequences](/Part%202%20-%20Sequence%20Basics/5.%20Transformation%20of%20sequences.md)  |

--- a/Part 2 - Sequence Basics/5. Transformation of sequences.md
+++ b/Part 2 - Sequence Basics/5. Transformation of sequences.md
@@ -487,4 +487,4 @@ Observable.range(1, 3)
 
 | Previous | Next |
 | --- | --- |
-| [Aggregation](/Part 2 - Sequence Basics/4. Aggregation.md) | [Chapter 3 - Taming the sequence](/Part 3 - Taming the sequence/1. Side effects.md) |
+| [Aggregation](/Part%202%20-%20Sequence%20Basics/4.%20Aggregation.md) |  [Chapter 3 - Taming the sequence](/Part%203%20-%20Taming%20the%20sequence/1.%20Side%20effects.md)  |

--- a/Part 3 - Taming the sequence/1. Side effects.md
+++ b/Part 3 - Taming the sequence/1. Side effects.md
@@ -329,4 +329,4 @@ The first subscriber is the first to be called for each item. Its action is to m
 
 | Previous | Next |
 | --- | --- |
-| [Transformation of sequences](/Part 2 - Sequence Basics/5. Transformation of sequences.md) | [Leaving the monad](/Part 3 - Taming the sequence/2. Leaving the monad.md) |
+| [Transformation of sequences](/Part%202%20-%20Sequence%20Basics/5.%20Transformation%20of%20sequences.md) | [Leaving the monad](/Part%203%20-%20Taming%20the%20sequence/2.%20Leaving%20the%20monad.md)  |

--- a/Part 3 - Taming the sequence/2. Leaving the monad.md
+++ b/Part 3 - Taming the sequence/2. Leaving the monad.md
@@ -325,4 +325,4 @@ Some blocking ways to access observables, such as `last()`, require the observab
 
 | Previous | Next |
 | --- | --- |
-| [Side effects](/Part 3 - Taming the sequence/1. Side effects.md) | [Advanced error handling](/Part 3 - Taming the sequence/3. Advanced error handling.md) |
+| [Side effects](/Part%203%20-%20Taming%20the%20sequence/1.%20Side%20effects.md) | [Advanced error handling](/Part%203%20-%20Taming%20the%20sequence/3.%20Advanced%20error%20handling.md)  |

--- a/Part 3 - Taming the sequence/3. Advanced error handling.md
+++ b/Part 3 - Taming the sequence/3. Advanced error handling.md
@@ -234,4 +234,4 @@ It is important to note here that we are responsible for terminating the observa
 
 | Previous | Next |
 | --- | --- |
-| [Leaving the monad](/Part 3 - Taming the sequence/2. Leaving the monad.md) | [Combining sequences](/Part 3 - Taming the sequence/4. Combining sequences.md) |
+| [Leaving the monad](/Part%203%20-%20Taming%20the%20sequence/2.%20Leaving%20the%20monad.md) | [Combining sequences](/Part%203%20-%20Taming%20the%20sequence/4.%20Combining%20sequences.md)  |

--- a/Part 3 - Taming the sequence/4. Combining sequences.md
+++ b/Part 3 - Taming the sequence/4. Combining sequences.md
@@ -673,4 +673,4 @@ I like to think of `combineLatest` as one event occuring in the context of anoth
 
 | Previous | Next |
 | --- | --- |
-| [Advanced error handling](/Part 3 - Taming the sequence/3. Advanced error handling.md) | [Time-shifted sequences](/Part 3 - Taming the sequence/5. Time-shifted sequences.md) |
+| [Advanced error handling](/Part%203%20-%20Taming%20the%20sequence/3.%20Advanced%20error%20handling.md) | [Time-shifted sequences](/Part%203%20-%20Taming%20the%20sequence/5.%20Time-shifted%20sequences.md)  |

--- a/Part 3 - Taming the sequence/5. Time-shifted sequences.md
+++ b/Part 3 - Taming the sequence/5. Time-shifted sequences.md
@@ -603,4 +603,4 @@ The output is the same as the previous two examples
 
 | Previous | Next |
 | --- | --- |
-| [Combining sequences](/Part 3 - Taming the sequence/4. Combining sequences.md) | [Hot and cold observables](/Part 3 - Taming the sequence/6. Hot and Cold observables.md) |
+| [Combining sequences](/Part%203%20-%20Taming%20the%20sequence/4.%20Combining%20sequences.md) | [Hot and cold observables](/Part%203%20-%20Taming%20the%20sequence/6.%20Hot%20and%20Cold%20observables.md)  |

--- a/Part 3 - Taming the sequence/6. Hot and Cold observables.md
+++ b/Part 3 - Taming the sequence/6. Hot and Cold observables.md
@@ -364,4 +364,4 @@ The `share` method is an alias for `Observable.publish().refCount()`. It allows 
 
 | Previous | Next |
 | --- | --- |
-| [Time-shifted sequences](/Part 3 - Taming the sequence/5. Time-shifted sequences.md) | [Custom operators](/Part 3 - Taming the sequence/7. Custom operators.md) |
+| [Time-shifted sequences](/Part%203%20-%20Taming%20the%20sequence/5.%20Time-shifted%20sequences.md) | [Custom operators](/Part%203%20-%20Taming%20the%20sequence/7.%20Custom%20operators.md)  |

--- a/Part 3 - Taming the sequence/7. Custom operators.md
+++ b/Part 3 - Taming the sequence/7. Custom operators.md
@@ -404,4 +404,4 @@ Theoretically, any operator can be implemented as both `Observable.Operator` and
 
 | Previous | Next |
 | --- | --- |
-| [Hot and cold observables](/Part 3 - Taming the sequence/6. Hot and Cold observables.md) | [Chapter 4 - Concurrency](/Part 4 - Concurrency/1. Scheduling and threading.md) |
+| [Hot and cold observables](/Part%203%20-%20Taming%20the%20sequence/6.%20Hot%20and%20Cold%20observables.md) | [Chapter 4 - Concurrency](/Part%204%20-%20Concurrency/1.%20Scheduling%20and%20threading.md)  |

--- a/Part 4 - Concurrency/1. Scheduling and threading.md
+++ b/Part 4 - Concurrency/1. Scheduling and threading.md
@@ -392,4 +392,4 @@ Again on 11
 
 | Previous | Next |
 | --- | --- |
-| [Custom operators](/Part 3 - Taming the sequence/7. Custom operators.md) | [Testing Rx](/Part 4 - Concurrency/2. Testing Rx.md) |
+| [Custom operators](/Part%203%20-%20Taming%20the%20sequence/7.%20Custom%20operators.md) | [Testing Rx](/Part%204%20-%20Concurrency/2.%20Testing%20Rx.md)  |

--- a/Part 4 - Concurrency/2. Testing Rx.md
+++ b/Part 4 - Concurrency/2. Testing Rx.md
@@ -227,4 +227,4 @@ Awaiting with a timeout will cause an exception if the observable fails to compl
 
 | Previous | Next |
 | --- | --- |
-| [Scheduling and threading](/Part 4 - Concurrency/1. Scheduling and threading.md) | [Sequences of coincidence](/Part 4 - Concurrency/3. Sequences of coincidence.md) |
+| [Scheduling and threading](/Part%204%20-%20Concurrency/1.%20Scheduling%20and%20threading.md) | [Sequences of coincidence](/Part%204%20-%20Concurrency/3.%20Sequences%20of%20coincidence.md)  |

--- a/Part 4 - Concurrency/3. Sequences of coincidence.md
+++ b/Part 4 - Concurrency/3. Sequences of coincidence.md
@@ -293,4 +293,4 @@ You can also implement `groupJoin` with `join` and `groupBy`. Doing so would req
 
 | Previous | Next |
 | --- | --- |
-| [Testing Rx](/Part 4 - Concurrency/2. Testing Rx.md) | [Backpressure](/Part 4 - Concurrency/4. Backpressure.md) |
+| [Testing Rx](/Part%204%20-%20Concurrency/2.%20Testing%20Rx.md) | [Backpressure](/Part%204%20-%20Concurrency/4.%20Backpressure.md)  |

--- a/Part 4 - Concurrency/4. Backpressure.md
+++ b/Part 4 - Concurrency/4. Backpressure.md
@@ -353,4 +353,4 @@ What we see here is that the first 128 items where consumed normally, but then w
 
 | Previous | Next |
 | --- | --- |
-| [Sequences of coincidence](/Part 4 - Concurrency/3. Sequences of coincidence.md) |  |
+| [Sequences of coincidence](/Part%204%20-%20Concurrency/3.%20Sequences%20of%20coincidence.md) |  |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This guide aims to introduce a beginner reactive programmer to the complete powe
 
 No experience with either reactive or functional programming is needed to follow the book. Familiarity with the basics of Java is required.
 
-[Begin learning](/Part 1 - Getting Started/1. Why Rx.md)
+[Begin learning](/Part%201%20-%20Getting%20Started/1.%20Why%20Rx.md)
 
 ### Structure
 


### PR DESCRIPTION
The new GitHub Flavored Markdown specs require dynamic link with no spaces. So, we have to use static link or encode the spaces. If we're still using spaces, the link won't shown (and it looks kinda weird
<img width="447" alt="screen shot 2017-03-27 at 11 52 32 pm" src="https://cloud.githubusercontent.com/assets/5099600/24371623/9abc8c5c-1355-11e7-801f-d4233f850122.png">
<img width="597" alt="screen shot 2017-03-27 at 11 52 12 pm" src="https://cloud.githubusercontent.com/assets/5099600/24371624/9ac474ee-1355-11e7-9d27-870fb689dd2a.png">

)