### PR TITLE
Fix wrong result on Side effects example

### DIFF
--- a/tests/java/itrx/chapter3/sideeffects/AsObservableExample.java
+++ b/tests/java/itrx/chapter3/sideeffects/AsObservableExample.java
@@ -85,7 +85,7 @@ public class AsObservableExample {
 		service.play();
 		
 		// Before: Greet
-		// After: Greet
+		// After: Later
 		// After: Hello
 		// After: and
 		// After: goodbye


### PR DESCRIPTION
In `exampleModifyReference()`, because we assign `service.items` with another BehaviorSubject instance, this subject no longer emits `Great` item, instead it will emit `Later`. I detected that when trying to learn [Side effects](https://github.com/Froussios/Intro-To-RxJava/blob/master/Part%203%20-%20Taming%20the%20sequence/1.%20Side%20effects.md) session.