### PR TITLE
Filter operator example mixes odd and even

### DIFF
--- a/Part 2 - Sequence Basics/2. Reducing a sequence.md
+++ b/Part 2 - Sequence Basics/2. Reducing a sequence.md
@@ -20,7 +20,7 @@ public final Observable<T> filter(Func1<? super T,java.lang.Boolean> predicate)
 
 ![](https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/filter.png)
 
-We will use `filter` to create a sequence of numbers and filter out all the even ones, keeping only odd values.
+We will use `filter` to create a sequence of numbers and filter out all the odd ones, keeping only even values.
 
 ```java
 Observable<Integer> values = Observable.range(0,10);


### PR DESCRIPTION
The code example for the filter operator filters out odd numbers leaving only even numbers. However the text description of it suggests it does the opposite. This PR corrects the text description to match the code example.