### PR TITLE
Fix doOnEach example in Part 3, Section 1

### DIFF
--- a/Part 3 - Taming the sequence/1. Side effects.md
+++ b/Part 3 - Taming the sequence/1. Side effects.md
@@ -141,7 +141,7 @@ Observable<String> values = Observable.just("side", "effects");
 		
 values
 	.doOnEach(new PrintSubscriber("Log"))
-	.map(s -> s.toUpperCase())
+	.map(s -> ((String) s).toUpperCase())
 	.subscribe(new PrintSubscriber("Process"));
 ```
 [Output](/tests/java/itrx/chapter3/sideeffects/DoOnExample.java)

--- a/tests/java/itrx/chapter3/sideeffects/DoOnExample.java
+++ b/tests/java/itrx/chapter3/sideeffects/DoOnExample.java
@@ -61,7 +61,7 @@ public class DoOnExample {
 
 		values
 		    .doOnEach(new PrintSubscriber("Log"))
-		    .map(s -> s.toUpperCase())
+		    .map(s -> ((String) s).toUpperCase())
 		    .subscribe(new PrintSubscriber("Process"));
 		
 		// Log: side


### PR DESCRIPTION
`doOnEach` seems to lose type info so following lambda in `map` needs to be explicitly typed.